### PR TITLE
bugfix/merge-resolvers-deep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mocha": "^3.1.2"
   },
   "dependencies": {
-    "extend": "^3.0.0"
+    "deep-assign": "^2.0.0"
   },
   "directories": {
     "test": "test"

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -1,4 +1,4 @@
-import extend from 'extend'
+import deepAssign from 'deep-assign'
 
 const defaultOptions = {
   rootKeys: {
@@ -68,7 +68,7 @@ const processModule = module => {
  * @return {Object} Options as expected by http://dev.apollodata.com/tools/graphql-tools/generate-schema.html#makeExecutableSchema.
  */
 export default (modules = [], options = {}) => {
-  options = extend(true, {}, defaultOptions, options)
+  options = deepAssign({}, defaultOptions, options)
   modules = modules.reduce((modules, module) => modules.concat(processModule(module)), []).reduce(flatten, [])
 
   const schema = modules.map(module => module.schema || '').filter(Boolean).join(`\n`)
@@ -76,10 +76,10 @@ export default (modules = [], options = {}) => {
   const mutations = modules.map(module => module.mutations || '').filter(Boolean).join(`\n`)
   const subscriptions = modules.map(module => module.subscriptions || '').filter(Boolean).join(`\n`)
 
-  const queriesResolvers = Object.assign.apply(null, modules.map(module => module.resolvers && module.resolvers.queries || {}))
-  const mutationsResolvers = Object.assign.apply(null, modules.map(module => module.resolvers && module.resolvers.mutations || {}))
-  const subscriptionsResolvers = Object.assign.apply(null, modules.map(module => module.resolvers && module.resolvers.subscriptions || {}))
-  const fieldResolvers = Object.assign.apply(null, modules.map(({ resolvers: { queries, mutations, subscriptions, ...fieldResolvers } = {} }) => fieldResolvers))
+  const queriesResolvers = deepAssign.apply(null, modules.map(module => module.resolvers && module.resolvers.queries || {}))
+  const mutationsResolvers = deepAssign.apply(null, modules.map(module => module.resolvers && module.resolvers.mutations || {}))
+  const subscriptionsResolvers = deepAssign.apply(null, modules.map(module => module.resolvers && module.resolvers.subscriptions || {}))
+  const fieldResolvers = deepAssign.apply(null, modules.map(({ resolvers: { queries, mutations, subscriptions, ...fieldResolvers } = {} }) => fieldResolvers))
 
   const resolvers = {
     ...(queries ? { RootQuery: queriesResolvers } : {}),

--- a/test/bundle.test.js
+++ b/test/bundle.test.js
@@ -197,6 +197,43 @@ describe('bundle', () => {
       expect(resolvers).to.have.deep.property('RootQuery.queryA')
       expect(resolvers).to.have.deep.property('RootQuery.queryB')
     })
+
+    it('should register multiple module and multiple resolvers for one type', () => {
+      const moduleA = {
+        schema: `
+          type ModuleA {
+            id: ID!,
+            moduleB: ModuleB,
+            moduleC: ModuleC
+          }
+        `,
+        queries: 'queryB(arg: String): String',
+        resolvers: { queries: { queryA: () => null } },
+      }
+
+      const moduleB = {
+        schema: `
+          type ModuleB {
+            id: ID!
+          }
+        `,
+        resolvers: { ModuleA: { moduleB: () => null } },
+      }
+
+      const moduleC = {
+        schema: `
+          type ModuleC {
+            id: ID!
+          }
+        `,
+        resolvers: { ModuleA: { moduleC: () => null } },
+      }
+
+      const { resolvers } = bundle([moduleA, moduleB, moduleC])
+
+      expect(resolvers).to.have.deep.property('ModuleA.moduleB')
+      expect(resolvers).to.have.deep.property('ModuleA.moduleC')
+    })
   })
 
   describe('alters', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,6 +999,12 @@ debug@~2.2.0, debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
+deep-assign:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-2.0.0.tgz#ebe06b1f07f08dae597620e3dd1622f371a1c572"
+  dependencies:
+    is-obj "^1.0.0"
+
 deep-eql@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
@@ -1255,7 +1261,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend, extend@~3.0.0:
+extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
@@ -1636,6 +1642,10 @@ is-number@^2.0.2, is-number@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
   dependencies:
     kind-of "^3.0.2"
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fix for merge resolvers.

Example:

schema_a 
`resolver: {
  foo: {
    bar: ()
  }
}`

schema_b
`resolver: {
  foo: {
    bar2: ()
  }
}`


results

`resolver: {
  foo: {
    bar: (),
    bar2: ()
  }
}`